### PR TITLE
Add headless flags and reduce fps

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ def stream_segment(
     filler_duration = max(available_time - segment_duration, 0)
     total_duration = segment_duration + filler_duration
 
-    fps = 30
+    fps = 25
     video_bitrate = "6800k"  # YouTube recommends ~6.8 Mbps for 1080p
     buffer_size = "13600k"  # 2x video bitrate for stability
     rtmp_url = f"rtmp://a.rtmp.youtube.com/live2/{stream_key}"

--- a/stream_url.py
+++ b/stream_url.py
@@ -20,7 +20,7 @@ async def _capture_frames(page, process: subprocess.Popen, fps: int) -> None:
     """Capture screenshots and write them to FFmpeg's stdin."""
     frame_delay = 1 / fps
     while process.poll() is None:
-        screenshot = await page.screenshot(type="png")
+        screenshot = await page.screenshot(type="jpeg", quality=80)
         try:
             if process.stdin:
                 process.stdin.write(screenshot)
@@ -168,7 +168,10 @@ async def run_livestream() -> None:
     future = loop.run_in_executor(executor, generate_tts_audio, [first_news], audio_path)
 
     async with async_playwright() as playwright:
-        browser = await playwright.chromium.launch()
+        browser = await playwright.chromium.launch(
+            headless=True,
+            args=["--disable-gpu", "--no-sandbox", "--disable-dev-shm-usage"],
+        )
         page = await browser.new_page(viewport={"width": 1920, "height": 1080})
         print(f"Streaming from {url}")
         await page.goto(url)


### PR DESCRIPTION
## Summary
- run static video segments at 25 fps
- capture frames as JPEG with lower quality
- launch Chromium headlessly with GPU disabled

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684673dfd0bc8328af9ac45334e03cc9