### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.git/
+audio/tts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/playwright/python:v1.42.0-jammy
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg git && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt && \
+    playwright install chromium
+
+# Copy application code
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ To livestream a website with scheduled news segments:
 python stream_url.py
 ```
 
+### Run with Docker
+
+Build the Docker image and start streaming:
+
+```bash
+docker build -t python-livestream .
+docker run --env-file .env python-livestream
+```
+
+To stream a website instead of an image:
+
+```bash
+docker run --env-file .env python-livestream python stream_url.py
+```
+
 ## Additional Notes
 
 - FFmpeg must be installed and available in your PATH.


### PR DESCRIPTION
## Summary
- add Dockerfile for running livestream in a container
- ignore caches in `.dockerignore`
- document container usage in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684689d5ae7083288dcdf03e084a2e64